### PR TITLE
build: ReleasesにTERMS.txtを含めるよう修正

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -27,11 +27,12 @@ jobs:
           cd $GITHUB_WORKSPACE
           python scripts/merge_vvm.py
 
-      - name: Prepare VVM files for release
+      - name: Prepare release files
         run: |
           cd $GITHUB_WORKSPACE
           mkdir -p release
           cp vvms/*.vvm release/
+          cp TERMS.txt release/
 
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## 内容

GitHub ActionsワークフローのReleasesでTERMS.txtもアップロードされるよう修正しました。

変更内容：
- `Prepare release files`ステップでTERMS.txtをreleaseディレクトリにコピーするよう追加
- ステップ名を「Prepare VVM files for release」から「Prepare release files」に変更（TERMS.txtも含むため）

これにより、次回リリース時からTERMS.txtもダウンロード可能になります。

## 関連 Issue

なし

## その他

🤖 Generated with [Claude Code](https://claude.ai/code)