### PR TITLE
ci: リリース作成に contents: write を明示する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## 内容

GITHUB_TOKEN のデフォルト権限を read-only にする準備として、write が必要な job に permissions を明示します。

- GitHub Release 作成 job に `contents: write` を明示します。
- public resource の read 用 permissions は追加していません。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
